### PR TITLE
Fixed multilabel files not being saved as Int

### DIFF
--- a/pumaz/image_processing.py
+++ b/pumaz/image_processing.py
@@ -240,6 +240,7 @@ def change_mask_labels(mask_file: str, label_map: dict, excluded_labels: list):
         data[np.isin(data, other_indices)] = 1
 
     # Save the modified image
+    data = data.astype(np.int16)
     new_img = nib.Nifti1Image(data, img.affine, img.header)
     nib.save(new_img, mask_file)
 
@@ -760,5 +761,6 @@ def apply_mask(image_file, mask_file, masked_img_file):
     mask = nib.load(mask_file).get_fdata()
     masked_img = image_data * mask
     # save the masked image with the header of the original image
+    masked_img = masked_img.astype(np.int16)
     nib.save(nib.Nifti1Image(masked_img, nib.load(image_file).affine, nib.load(image_file).header), masked_img_file)
     return masked_img_file


### PR DESCRIPTION
## Pull Request

**Description:**

The intensities of the labels were being saved as floats instead of integers. Fixed this behaviour to always save np.Int16

**Changes Made:**

- Added line 243 in image processing
- Added line 764 in image processing


**Reviewer Checklist:**

- [x] Code is clean and follows the team's coding standards.
- [ ] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated or added if necessary.
- [x] The code builds and runs without errors.
- [ ] The changes have been tested on relevant environments or browsers.
- [x] Any relevant dependencies have been updated.
- [x] The changes have been reviewed for security implications.

**Additional Notes:**


